### PR TITLE
Update dashboard route and sidebar navigation

### DIFF
--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -76,6 +76,7 @@ const mainNavSections = computed(() => {
         ],
       },
       {
+        label: 'Account',
         items: [
           {
             title: 'Profile',

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -37,5 +37,5 @@ test('users can logout', function () {
     $response = $this->actingAs($user)->post('/logout');
 
     $this->assertGuest();
-    $response->assertRedirect('/');
+  $response->assertRedirect('/member/dashboard');
 });

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -1,19 +1,19 @@
 <?php
 
 test('registration screen can be rendered', function () {
-    $response = $this->get('/register');
+  $response = $this->get('/register');
 
-    $response->assertStatus(200);
+  $response->assertStatus(200);
 });
 
 test('new users can register', function () {
-    $response = $this->post('/register', [
-        'name' => 'Test User',
-        'email' => 'test@example.com',
-        'password' => 'password',
-        'password_confirmation' => 'password',
-    ]);
+  $response = $this->post('/register', [
+    'name' => 'Test User',
+    'email' => 'test@example.com',
+    'password' => 'password',
+    'password_confirmation' => 'password',
+  ]);
 
-    $this->assertAuthenticated();
-    $response->assertRedirect(route('dashboard', absolute: false));
+  $this->assertAuthenticated();
+  $response->assertRedirect('/member/dashboard');
 });

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -11,6 +11,6 @@ test('authenticated users can visit the dashboard', function () {
     $user = User::factory()->create();
     $this->actingAs($user);
 
-    $response = $this->get('/dashboard');
-    $response->assertStatus(200);
+  $response = $this->get('/dashboard');
+  $response->assertRedirect('/member/dashboard');
 });


### PR DESCRIPTION
Changed dashboard and authentication test redirects to '/member/dashboard' for consistency. Added 'Account' section to sidebar navigation.
