### PR TITLE
Update authentication tests for member role

### DIFF
--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -4,23 +4,10 @@ use App\Models\User;
 
 test('login screen can be rendered', function () {
   $response = $this->get('/login');
-
   $response->assertStatus(200);
 });
 
-test('users can authenticate using the login screen', function () {
-  $user = User::factory()->create(['role' => 'member']);
-
-  $response = $this->post('/login', [
-    'email' => $user->email,
-    'password' => 'password',
-  ]);
-
-  $this->assertAuthenticated();
-  $response->assertRedirect(route('dashboard', absolute: false));
-});
-
-test('users can authenticate using the login screen', function () {
+test('members can authenticate and are redirected to member dashboard', function () {
   $user = User::factory()->create(['role' => 'member']);
 
   $response = $this->post('/login', [
@@ -32,11 +19,22 @@ test('users can authenticate using the login screen', function () {
   $response->assertRedirect('/member/dashboard');
 });
 
+test('users can not authenticate with invalid password', function () {
+  $user = User::factory()->create(['role' => 'member']);
+
+  $this->post('/login', [
+    'email' => $user->email,
+    'password' => 'wrong-password',
+  ]);
+
+  $this->assertGuest();
+});
+
 test('users can logout', function () {
-  $user = User::factory()->create();
+  $user = User::factory()->create(['role' => 'member']);
 
   $response = $this->actingAs($user)->post('/logout');
 
   $this->assertGuest();
-  $response->assertRedirect('/');
+  $response->assertRedirect('/'); // adjust this if your logout redirect is different
 });


### PR DESCRIPTION
Refactored authentication tests to specifically check member role login and redirection to /member/dashboard. Added a test for invalid password authentication and ensured logout test uses member role for consistency.