### PR TITLE
Refactor member account and forms routes and views

### DIFF
--- a/app/Http/Controllers/Member/AccountController.php
+++ b/app/Http/Controllers/Member/AccountController.php
@@ -6,10 +6,10 @@ use App\Http\Controllers\Controller;
 use Inertia\Inertia;
 use Inertia\Response;
 
-class ProfileController extends Controller
+class AccountController extends Controller
 {
   public function index(): Response
   {
-    return Inertia::render('member/Profile');
+    return Inertia::render('member/cooperative/Account');
   }
 }

--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -76,11 +76,11 @@ const mainNavSections = computed(() => {
         ],
       },
       {
-        label: 'Account',
+        label: 'Cooperative',
         items: [
           {
-            title: 'Profile',
-            href: '/member/profile',
+            title: 'Account',
+            href: '/member/cooperative/account',
             icon: User,
           },
         ],
@@ -88,8 +88,8 @@ const mainNavSections = computed(() => {
       {
         label: 'Forms',
         items: [
-          { title: 'Member Form', href: '/member/forms/member', icon: FileText },
-          { title: 'Loan Form', href: '/member/forms/loan', icon: FileText },
+          { title: 'Member Form', href: '/member/forms/member-application', icon: FileText },
+          { title: 'Loan Form', href: '/member/forms/loan-application', icon: FileText },
         ],
       },
     ]

--- a/resources/js/pages/member/Profile.vue
+++ b/resources/js/pages/member/Profile.vue
@@ -1,9 +1,0 @@
-<script setup lang="ts">
-
-</script>
-
-<template>
-  <div>
-
-  </div>
-</template>

--- a/resources/js/pages/member/cooperative/Account.vue
+++ b/resources/js/pages/member/cooperative/Account.vue
@@ -5,12 +5,12 @@ import { Head } from '@inertiajs/vue3'
 
 const breadcrumbs: BreadcrumbItem[] = [
   { title: 'Dashboard', href: '/member/dashboard' },
-  { title: 'Loan Application', href: '/member/forms/loan-application' },
+  { title: 'Account', href: '/member/cooperative/account' },
 ]
 </script>
 
 <template>
-  <Head title="Loan Application" />
+  <Head title="Account" />
 
   <AppLayout :breadcrumbs="breadcrumbs">
     <div class="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">

--- a/resources/js/pages/member/forms/MemberForm.vue
+++ b/resources/js/pages/member/forms/MemberForm.vue
@@ -1,9 +1,20 @@
 <script setup lang="ts">
+import AppLayout from '@/layouts/AppLayout.vue'
+import { type BreadcrumbItem } from '@/types'
+import { Head } from '@inertiajs/vue3'
 
+const breadcrumbs: BreadcrumbItem[] = [
+  { title: 'Dashboard', href: '/member/dashboard' },
+  { title: 'Member Application', href: '/member/forms/member-application' },
+]
 </script>
 
 <template>
-  <div>
+  <Head title="Member Application" />
 
-  </div>
+  <AppLayout :breadcrumbs="breadcrumbs">
+    <div class="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
+
+    </div>
+  </AppLayout>
 </template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,7 +8,7 @@ use App\Http\Controllers\Admin\MemberManagementController;
 use App\Http\Controllers\Admin\UtilityController;
 use App\Http\Controllers\Member\DashboardController as MemberDashboardController;
 use App\Http\Controllers\Member\FormController;
-use App\Http\Controllers\Member\ProfileController;
+use App\Http\Controllers\Member\AccountController;
 
 // Public Pages
 Route::get('/', fn() => Inertia::render('Home'))->name('home');
@@ -42,7 +42,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
   // Admin Routes
   // ------------------
   Route::middleware('role:admin')->prefix('admin')->name('admin.')->group(function () {
-    Route::get('/dashboard', [AdminDashboardController::class, 'index'])->name('dashboard');
+    Route::get('dashboard', [AdminDashboardController::class, 'index'])->name('dashboard');
 
     Route::prefix('management')->name('management.')->group(function () {
       Route::resource('members', MemberManagementController::class);
@@ -59,12 +59,15 @@ Route::middleware(['auth', 'verified'])->group(function () {
   // Member Routes
   // ------------------
   Route::middleware('role:member')->prefix('member')->name('member.')->group(function () {
-    Route::get('/dashboard', [MemberDashboardController::class, 'index'])->name('dashboard');
-    Route::get('/profile', [ProfileController::class, 'index'])->name('profile');
+    Route::get('dashboard', [MemberDashboardController::class, 'index'])->name('dashboard');
+
+    Route::prefix('cooperative')->group(function () {
+      Route::get('account', [AccountController::class, 'index'])->name('account');
+    });
 
     Route::prefix('forms')->group(function () {
-      Route::get('member', [FormController::class, 'memberForm'])->name('forms.member');
-      Route::get('loan', [FormController::class, 'loanForm'])->name('forms.loan');
+      Route::get('member-application', [FormController::class, 'memberForm'])->name('forms.member');
+      Route::get('loan-application', [FormController::class, 'loanForm'])->name('forms.loan');
     });
   });
 });


### PR DESCRIPTION
Renamed ProfileController to AccountController and updated its route and view to 'cooperative/account'. Updated sidebar navigation and routes to reflect new paths for account and forms (member-application, loan-application). Added breadcrumbs and layout to MemberForm and LoanForm views. Removed obsolete Profile.vue.
