### PR TITLE
Show membership status and pending notices for members

### DIFF
--- a/app/Http/Controllers/Member/AccountController.php
+++ b/app/Http/Controllers/Member/AccountController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Member;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -10,6 +11,11 @@ class AccountController extends Controller
 {
   public function index(): Response
   {
-    return Inertia::render('member/cooperative/Account');
+    $user = Auth::user();
+    $status = $user->member?->membership_status ?? 'none';
+
+    return Inertia::render('member/cooperative/Account', [
+      'status' => $status,
+    ]);
   }
 }

--- a/app/Http/Controllers/Member/DashboardController.php
+++ b/app/Http/Controllers/Member/DashboardController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Member;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -10,6 +11,11 @@ class DashboardController extends Controller
 {
   public function index(): Response
   {
-    return Inertia::render('member/Dashboard');
+    $user = Auth::user();
+    $status = $user->member?->membership_status ?? 'none';
+
+    return Inertia::render('member/Dashboard', [
+      'status' => $status,
+    ]);
   }
 }

--- a/app/Http/Controllers/Member/FormController.php
+++ b/app/Http/Controllers/Member/FormController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Member;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -15,6 +16,11 @@ class FormController extends Controller
 
   public function loanForm(): Response
   {
-    return Inertia::render('member/forms/LoanForm');
+    $user = Auth::user();
+    $status = $user->member?->membership_status ?? 'none';
+
+    return Inertia::render('member/forms/LoanForm', [
+      'status' => $status
+    ]);
   }
 }

--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -14,23 +14,12 @@ import {
 } from '@/components/ui/sidebar'
 
 import { Link, usePage } from '@inertiajs/vue3'
-import {
-  IconBrandFacebook,
-  IconBrandGithub,
-} from '@tabler/icons-vue'
+import { IconBrandFacebook, IconBrandGithub } from '@tabler/icons-vue'
 
-import {
-  Calculator,
-  Calendar,
-  Download,
-  FileWarning,
-  LayoutGrid,
-  User,
-  FileText,
-} from 'lucide-vue-next'
+import { Calculator, Calendar, FileText, FileWarning, Home, LayoutGrid, User } from 'lucide-vue-next'
 
-import AppLogo from './AppLogo.vue'
 import { computed } from 'vue'
+import AppLogo from './AppLogo.vue'
 
 const page = usePage()
 const role = page.props.auth.user.role as 'admin' | 'member'
@@ -40,6 +29,11 @@ const mainNavSections = computed(() => {
     return [
       {
         items: [
+          {
+            title: 'Home',
+            href: '/',
+            icon: Home,
+          },
           {
             title: 'Dashboard',
             href: '/admin/dashboard',
@@ -68,6 +62,11 @@ const mainNavSections = computed(() => {
     return [
       {
         items: [
+          {
+            title: 'Home',
+            href: '/',
+            icon: Home,
+          },
           {
             title: 'Dashboard',
             href: '/member/dashboard',
@@ -111,7 +110,6 @@ const footerNavItems = [
   },
 ]
 </script>
-
 
 <template>
   <Sidebar collapsible="icon" variant="floating">

--- a/resources/js/pages/member/Dashboard.vue
+++ b/resources/js/pages/member/Dashboard.vue
@@ -2,12 +2,13 @@
 import AppLayout from '@/layouts/AppLayout.vue'
 import { type BreadcrumbItem } from '@/types'
 import { Head } from '@inertiajs/vue3'
-import PlaceholderPattern from '../../components/PlaceholderPattern.vue'
+
+defineProps<{ status: string }>()
 
 const breadcrumbs: BreadcrumbItem[] = [
   {
     title: 'Dashboard',
-    href: '/dashboard',
+    href: '/member/dashboard',
   },
 ]
 </script>
@@ -17,28 +18,37 @@ const breadcrumbs: BreadcrumbItem[] = [
 
   <AppLayout :breadcrumbs="breadcrumbs">
     <div class="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
-      <div class="grid auto-rows-min gap-4 md:grid-cols-3">
-        <div
-          class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border"
-        >
-          <PlaceholderPattern />
+      <template v-if="status === 'pending'">
+        <div class="space-y-4 rounded-lg border border-yellow-400 bg-yellow-100 p-6 text-yellow-800 shadow">
+          <h2 class="text-lg font-semibold">Membership Pending</h2>
+
+          <p>
+            Your membership is still pending approval. To access <u>full dashboard features</u>, please complete the
+            following requirements:
+          </p>
+
+          <ul class="list-inside list-disc space-y-1">
+            <li>Attend the PMES (Pre-Membership Education Seminar)</li>
+            <li>Fill out and submit the Membership Application Form</li>
+            <li>Submit a valid government-issued ID</li>
+            <li>Pay the initial membership fee</li>
+          </ul>
+
+          <p>
+            You may fill out the membership form online:
+            <a href="/member/forms/member-application" class="ml-1 text-blue-700 underline hover:text-blue-900">
+              Complete Member Form
+            </a>
+          </p>
+
+          <p class="text-sm italic">For further assistance, please contact the cooperative office.</p>
         </div>
-        <div
-          class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border"
-        >
-          <PlaceholderPattern />
-        </div>
-        <div
-          class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border"
-        >
-          <PlaceholderPattern />
-        </div>
-      </div>
-      <div
-        class="relative min-h-[100vh] flex-1 rounded-xl border border-sidebar-border/70 md:min-h-min dark:border-sidebar-border"
-      >
-        <PlaceholderPattern />
-      </div>
+      </template>
+
+      <template v-else>
+        <!-- Full member dashboard content here -->
+        <h1 class="text-xl font-bold">Welcome to your Dashboard</h1>
+      </template>
     </div>
   </AppLayout>
 </template>

--- a/resources/js/pages/member/cooperative/Account.vue
+++ b/resources/js/pages/member/cooperative/Account.vue
@@ -3,6 +3,8 @@ import AppLayout from '@/layouts/AppLayout.vue'
 import { type BreadcrumbItem } from '@/types'
 import { Head } from '@inertiajs/vue3'
 
+defineProps<{ status: string }>()
+
 const breadcrumbs: BreadcrumbItem[] = [
   { title: 'Dashboard', href: '/member/dashboard' },
   { title: 'Account', href: '/member/cooperative/account' },
@@ -14,7 +16,38 @@ const breadcrumbs: BreadcrumbItem[] = [
 
   <AppLayout :breadcrumbs="breadcrumbs">
     <div class="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
+      <template v-if="status === 'pending'">
+        <div class="space-y-4 rounded-lg border border-yellow-400 bg-yellow-100 p-6 text-yellow-800 shadow">
+          <h2 class="text-lg font-semibold">Membership Pending</h2>
 
+          <p>
+            Your membership is still pending approval. To access your <u>full account details</u>, please complete the
+            following requirements:
+          </p>
+
+          <ul class="list-inside list-disc space-y-1">
+            <li>Attend the PMES (Pre-Membership Education Seminar)</li>
+            <li>Fill out and submit the Membership Application Form</li>
+            <li>Submit a valid government-issued ID</li>
+            <li>Pay the initial membership fee</li>
+          </ul>
+
+          <p>
+            You may fill out the membership form online:
+            <a href="/member/forms/member-application" class="ml-1 text-blue-700 underline hover:text-blue-900">
+              Complete Member Form
+            </a>
+          </p>
+
+          <p class="text-sm italic">For further assistance, please contact the cooperative office.</p>
+        </div>
+      </template>
+
+      <template v-else>
+        <!-- Account details go here -->
+        <h1 class="text-xl font-semibold">Account Information</h1>
+        <!-- Replace or extend with actual member account display -->
+      </template>
     </div>
   </AppLayout>
 </template>

--- a/resources/js/pages/member/forms/LoanForm.vue
+++ b/resources/js/pages/member/forms/LoanForm.vue
@@ -3,6 +3,8 @@ import AppLayout from '@/layouts/AppLayout.vue'
 import { type BreadcrumbItem } from '@/types'
 import { Head } from '@inertiajs/vue3'
 
+defineProps<{ status: string }>()
+
 const breadcrumbs: BreadcrumbItem[] = [
   { title: 'Dashboard', href: '/member/dashboard' },
   { title: 'Loan Application', href: '/member/forms/loan-application' },
@@ -14,7 +16,37 @@ const breadcrumbs: BreadcrumbItem[] = [
 
   <AppLayout :breadcrumbs="breadcrumbs">
     <div class="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
+      <template v-if="status === 'pending'">
+        <div class="space-y-4 rounded-lg border border-yellow-400 bg-yellow-100 p-6 text-yellow-800 shadow">
+          <h2 class="text-lg font-semibold">Membership Pending</h2>
 
+          <p>
+            Your membership is still pending approval. To proceed with a <u>loan application</u>, please complete the
+            following requirements:
+          </p>
+
+          <ul class="list-inside list-disc space-y-1">
+            <li>Attend the PMES (Pre-Membership Education Seminar)</li>
+            <li>Fill out and submit the Membership Application Form</li>
+            <li>Submit a valid government-issued ID</li>
+            <li>Pay the initial membership fee</li>
+          </ul>
+
+          <p>
+            You may fill out the membership form online:
+            <a href="/member/forms/member-application" class="ml-1 text-blue-700 underline hover:text-blue-900">
+              Complete Member Form
+            </a>
+          </p>
+
+          <p class="text-sm italic">For further assistance, please contact the cooperative office.</p>
+        </div>
+      </template>
+
+      <template v-else>
+        <!-- Your loan application form goes here -->
+        <h1>Hello World</h1>
+      </template>
     </div>
   </AppLayout>
 </template>

--- a/resources/js/pages/member/forms/MemberForm.vue
+++ b/resources/js/pages/member/forms/MemberForm.vue
@@ -13,8 +13,6 @@ const breadcrumbs: BreadcrumbItem[] = [
   <Head title="Member Application" />
 
   <AppLayout :breadcrumbs="breadcrumbs">
-    <div class="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
-
-    </div>
+    <div class="flex h-full flex-1 flex-col gap-4 rounded-xl p-4"></div>
   </AppLayout>
 </template>


### PR DESCRIPTION
Controllers now pass membership status to Inertia views for member pages. Member dashboard, account, and loan form pages display a pending membership notice and requirements if the user's status is 'pending', improving onboarding clarity. Sidebar navigation and breadcrumbs were also updated for consistency.
